### PR TITLE
Simplified and fixed the container_uptime template filter.

### DIFF
--- a/shipyard/templatetags/shipyard.py
+++ b/shipyard/templatetags/shipyard.py
@@ -2,8 +2,7 @@ from django import template
 from django.template.defaultfilters import stringfilter
 from django.utils.translation import ugettext as _
 from containers.models import Host
-from datetime import datetime, timedelta
-import time
+from datetime import datetime
 
 register = template.Library()
 
@@ -32,11 +31,8 @@ def container_uptime(value):
     if value:
         try:
             tz = value.split('.')[-1]
-            now = time.mktime(datetime.fromtimestamp(time.time()).timetuple())
-            ts = time.mktime(datetime.fromtimestamp(time.mktime(time.strptime(value,
-                '%Y-%m-%dT%H:%M:%S.' + tz))).timetuple())
-            diff = now-ts
-            return timedelta(seconds=diff)
+            ts = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.' + tz)
+            return datetime.utcnow().replace(microsecond=0) - ts
         except:
             return ''
     return value


### PR DESCRIPTION
The function was quite complex and showed -1 day 20:00:00 on start of a new container for me. This should be correct now.
