### PR TITLE
Support quoted environment variables

### DIFF
--- a/containers/views.py
+++ b/containers/views.py
@@ -33,6 +33,7 @@ import urllib
 import random
 import json
 import tempfile
+import shlex
 
 def handle_upload(f):
     tmp_file = tempfile.mktemp()
@@ -90,7 +91,7 @@ def create_container(request):
             if environment.strip() == '':
                 environment = None
             else:
-                environment = environment.split()
+                environment = shlex.split(environment)
             if memory.strip() == '':
                 memory = 0
             # build volumes


### PR DESCRIPTION
This change makes use of shlex to correctly parse the environment options and work around quoted values. 

For example:

```
Python 2.7.5 (default, May 15 2013, 22:43:36) [MSC v.1500 32 bit (Intel)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> "QUEUEBOT_USERNAME=bot1@bot.pleaseignore.com QUEUEBOT_PASSWORD=\"Lines are awesome!!\"".split()
['QUEUEBOT_USERNAME=bot1@bot.pleaseignore.com', 'QUEUEBOT_PASSWORD="Lines', 'are', 'awesome!!"']
>>> import shlex
>>> shlex.split("QUEUEBOT_USERNAME=bot1@bot.pleaseignore.com QUEUEBOT_PASSWORD=\"Lines are awesome!!\"")
['QUEUEBOT_USERNAME=bot1@bot.pleaseignore.com', 'QUEUEBOT_PASSWORD=Lines are awesome!!']
>>>
```
