### PR TITLE
Feature/natea/aws provider

### DIFF
--- a/README-AWS.md
+++ b/README-AWS.md
@@ -62,14 +62,16 @@ If you want to access Shipyard on port 80 rather than port 8000, you can add an 
 
 ```
 $ redis-ctl
-redis 127.0.0.1:6379> rpush frontend:ec2-54-211-218-200.compute-1.amazonaws.com shipyard
-redis 127.0.0.1:6379> rpush frontend:ec2-54-211-218-200.compute-1.amazonaws.com http://127.0.0.1:8000
+redis 127.0.0.1:6379> rpush frontend:ec2-xxx-xxx-xxx-xxx.compute-1.amazonaws.com shipyard
+redis 127.0.0.1:6379> rpush frontend:ec2-xxx-xxx-xxx-xxx.compute-1.amazonaws.com http://127.0.0.1:8000
 ```
+
+Note: replace ``ec2-xxx-xxx-xxx-xxx.compute-1.amazonaws.com`` with whatever your EC2 instance's public DNS is.
 
 Confirm that they are in the datastore.
 
 ```
-redis 127.0.0.1:6379> lrange frontend:ec2-54-211-218-200.compute-1.amazonaws.com 0 -1
+redis 127.0.0.1:6379> lrange frontend:ec2-xxx-xxx-xxx-xxx.compute-1.amazonaws.com 0 -1
 1) "shipyard"
 2) "http://127.0.0.1:8000"
 ```

--- a/README-AWS.md
+++ b/README-AWS.md
@@ -1,0 +1,88 @@
+# Run Shipyard on AWS
+
+You can run Shipyard on AWS by using the Vagrantfile-aws file which will use the provision-aws.sh script instead of the normal provision.sh.
+
+```
+$ mv Vagrantfile Vagrantfile-normal
+$ mv Vagrantfile-aws Vagrantfile
+```
+
+## Install the vagrant-aws plugin
+
+In order for Vagrant to provision to AWS, you need to install the vagrant-aws plugin.
+
+```
+$ vagrant plugin install vagrant-aws
+```
+
+See the [vagrant-aws](https://github.com/mitchellh/vagrant-aws/) page for more info.
+
+## Configure the AWS environment variables
+
+You need to edit the aws.sh file and add your AWS keys and such. Then source these so they're available to the script.
+
+```
+$ source aws.sh
+```
+
+## Create a security group named "shipyard" using the AWS console
+
+If you want to be able to launch applications on non-standard ports, you need to create a new security group with special ports opened. You can do think from the [AWS console](https://console.aws.amazon.com/ec2/home?#s=SecurityGroups).
+
+You should open ports 22, 80 and 4000-50000 (don't open these ports for production but for testing it's fine)
+
+## Create the EC2 instance
+
+Next you can run ``vagrant up`` and pass in the provider value to ``aws``.
+
+```
+$ vagrant up --provider=aws
+```
+
+## Make sure the services are running
+
+Login to the newly created EC2 instance and see that the services are running.
+
+```
+$ vagrant ssh
+$ sudo supervisorctl status
+app                              RUNNING   
+hipache                          RUNNING   
+redis                            RUNNING   
+worker                           RUNNING   
+```
+
+If any of them aren't running, find out why by looking at the log files in ``/var/log/supervisor``.
+
+You should now be able to access Shipyard on port 8000.
+
+## Add Shipyard to Hipache so you can access it on port 80
+
+If you want to access Shipyard on port 80 rather than port 8000, you can add an entry in Redis that Hipache will use to route all requests to Shipyard.
+
+```
+$ redis-ctl
+redis 127.0.0.1:6379> rpush frontend:ec2-54-211-218-200.compute-1.amazonaws.com shipyard
+redis 127.0.0.1:6379> rpush frontend:ec2-54-211-218-200.compute-1.amazonaws.com http://127.0.0.1:8000
+```
+
+Confirm that they are in the datastore.
+
+```
+redis 127.0.0.1:6379> lrange frontend:ec2-54-211-218-200.compute-1.amazonaws.com 0 -1
+1) "shipyard"
+2) "http://127.0.0.1:8000"
+```
+
+Before you can start using Shipyard, you need to add the host. Click on the 'Hosts' tab, and add your public IP address (which will resolve to the internal IP) and the port 4243. Now you can proceed to the 'Images' tab and start adding images.
+
+## Move the Docker containers to /mnt
+
+The default EC2 instances only come with 10GB on the root volume, but there is a large volume at /mnt. To avoid running out of diskspace on the root volume.
+
+```
+sudo service docker stop
+sudo mv /var/lib/docker /mnt/docker && ln -s /mnt/docker /var/lib/docker
+```
+
+Please note that if you are going to use this in production then you should mount an EBS volume so that the data is persisted. Any data stored in /mnt will be lost if the machine is stopped or terminated.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-AWS_REGION = ENV['AWS_REGION'] || "us-east-1"
-AWS_AMI    = ENV['AWS_AMI']    || "ami-d0f89fb9"
-
 Vagrant::Config.run do |config|
   config.vm.box = "raring64"
   config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/raring/current/raring-server-cloudimg-amd64-vagrant-disk1.box"
@@ -18,12 +15,10 @@ Vagrant::Config.run do |config|
   end
 end
 
-# Providers were added on Vagrant >= 1.1.0
 Vagrant.configure("2") do |config|
     config.vm.provider :virtualbox do |v|
         v.customize ["modifyvm", :id, "--memory", 2048]
     end
-
     config.vm.provider :vmware_fusion do |v|
       config.vm.define :shipyard do |s|
         v.vmx["memsize"] = "2048"
@@ -32,27 +27,4 @@ Vagrant.configure("2") do |config|
         v.vmx["displayName"] = "shipyard"
       end
     end
-
-    config.vm.provider :aws do |aws, override|
-      override.provision :shell, :path => "provision-aws.sh"
-      aws.access_key_id = ENV["AWS_ACCESS_KEY_ID"]
-      aws.secret_access_key = ENV["AWS_SECRET_ACCESS_KEY"]
-      aws.keypair_name = ENV["AWS_KEYPAIR_NAME"]
-      override.ssh.private_key_path = ENV["AWS_SSH_PRIVKEY"]
-      override.ssh.username = "ubuntu"
-      aws.region = AWS_REGION
-      aws.ami    = AWS_AMI
-      aws.instance_type = "m1.small"
-    end
-
-    config.vm.provider :rackspace do |rs|
-      config.ssh.private_key_path = ENV["RS_PRIVATE_KEY"]
-      rs.username = ENV["RS_USERNAME"]
-      rs.api_key  = ENV["RS_API_KEY"]
-      rs.public_key_path = ENV["RS_PUBLIC_KEY"]
-      rs.flavor   = /512MB/
-      rs.image    = /Ubuntu/
-    end
 end
-
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+AWS_REGION = ENV['AWS_REGION'] || "us-east-1"
+AWS_AMI    = ENV['AWS_AMI']    || "ami-d0f89fb9"
+
 Vagrant::Config.run do |config|
   config.vm.box = "raring64"
   config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/raring/current/raring-server-cloudimg-amd64-vagrant-disk1.box"
@@ -15,10 +18,12 @@ Vagrant::Config.run do |config|
   end
 end
 
+# Providers were added on Vagrant >= 1.1.0
 Vagrant.configure("2") do |config|
     config.vm.provider :virtualbox do |v|
         v.customize ["modifyvm", :id, "--memory", 2048]
     end
+
     config.vm.provider :vmware_fusion do |v|
       config.vm.define :shipyard do |s|
         v.vmx["memsize"] = "2048"
@@ -27,4 +32,27 @@ Vagrant.configure("2") do |config|
         v.vmx["displayName"] = "shipyard"
       end
     end
+
+    config.vm.provider :aws do |aws, override|
+      override.provision :shell, :path => "provision-aws.sh"
+      aws.access_key_id = ENV["AWS_ACCESS_KEY_ID"]
+      aws.secret_access_key = ENV["AWS_SECRET_ACCESS_KEY"]
+      aws.keypair_name = ENV["AWS_KEYPAIR_NAME"]
+      override.ssh.private_key_path = ENV["AWS_SSH_PRIVKEY"]
+      override.ssh.username = "ubuntu"
+      aws.region = AWS_REGION
+      aws.ami    = AWS_AMI
+      aws.instance_type = "m1.small"
+    end
+
+    config.vm.provider :rackspace do |rs|
+      config.ssh.private_key_path = ENV["RS_PRIVATE_KEY"]
+      rs.username = ENV["RS_USERNAME"]
+      rs.api_key  = ENV["RS_API_KEY"]
+      rs.public_key_path = ENV["RS_PUBLIC_KEY"]
+      rs.flavor   = /512MB/
+      rs.image    = /Ubuntu/
+    end
 end
+
+

--- a/Vagrantfile-aws
+++ b/Vagrantfile-aws
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+AWS_REGION = ENV['AWS_REGION'] || "us-east-1"
+AWS_AMI    = ENV['AWS_AMI']    || "ami-d0f89fb9"
+AWS_INSTANCE_TYPE = ENV['AWS_INSTANCE_TYPE'] || "m1.small"
+AWS_SECURITY_GROUPS = ["shipyard"]
+
+#     aws.ami = "ami-7747d01e"
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "dummy"
+  config.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
+  config.vm.synced_folder ".", "/opt/apps/shipyard"
+  config.vm.provision :shell, :path => "provision-aws.sh"
+
+  config.vm.provider :aws do |aws, override|
+    aws.access_key_id = ENV["AWS_ACCESS_KEY_ID"]
+    aws.secret_access_key = ENV["AWS_SECRET_ACCESS_KEY"]
+    aws.keypair_name = ENV["AWS_KEYPAIR_NAME"]
+    aws.security_groups = AWS_SECURITY_GROUPS
+    aws.region = AWS_REGION
+    aws.ami    = AWS_AMI
+    aws.instance_type = AWS_INSTANCE_TYPE
+
+    override.ssh.private_key_path = ENV["AWS_SSH_PRIVKEY"]
+    override.ssh.username = "ubuntu"
+  end
+end
+

--- a/aws.sh
+++ b/aws.sh
@@ -1,0 +1,16 @@
+# for Shipyard's Vagrantfile to deploy Shipyard to AWS
+
+#aws.access_key_id = ENV["AWS_ACCESS_KEY_ID"]
+export AWS_ACCESS_KEY_ID='replaceme'
+
+#aws.secret_access_key = ENV["AWS_SECRET_ACCESS_KEY"]
+export AWS_SECRET_ACCESS_KEY='replaceme'                                                                                                  
+
+#aws.keypair_name = ENV["AWS_KEYPAIR_NAME"]
+export AWS_KEYPAIR_NAME='shipyard'
+
+#override.ssh.private_key_path = ENV["AWS_SSH_PRIVKEY"]
+export AWS_SSH_PRIVKEY='/home/username/.ssh/shipyard.pem'
+
+#AWS_REGION = ENV['AWS_REGION'] || "us-east-1"
+#AWS_AMI    = ENV['AWS_AMI']    || "ami-d0f89fb9"

--- a/aws.sh
+++ b/aws.sh
@@ -12,5 +12,6 @@ export AWS_KEYPAIR_NAME='shipyard'
 #override.ssh.private_key_path = ENV["AWS_SSH_PRIVKEY"]
 export AWS_SSH_PRIVKEY='/home/username/.ssh/shipyard.pem'
 
+#export AWS_SECURITY_GROUPS='["shipyard"]'
 #AWS_REGION = ENV['AWS_REGION'] || "us-east-1"
 #AWS_AMI    = ENV['AWS_AMI']    || "ami-d0f89fb9"

--- a/provision-aws.sh
+++ b/provision-aws.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-APP_DIR=/opt/app
+APP_DIR=/opt/apps
 VE_ROOT=/opt/ve
 VE_DIR=$VE_ROOT/shipyard
 NODE_URL='http://nodejs.org/dist/v0.10.12/node-v0.10.12.tar.gz'

--- a/provision-aws.sh
+++ b/provision-aws.sh
@@ -12,7 +12,7 @@ if [ -e "/etc/.provisioned" ] ; then
 fi
 
 apt-get -qq update
-DEBIAN_FRONTEND=noninteractive apt-get -qq install -y python-software-properties s3cmd git-core linux-image-extra-`uname -r` bridge-utils bsdtar lxc wget ruby python-dev libxml2-dev python-setuptools redis-server supervisor
+DEBIAN_FRONTEND=noninteractive apt-get -qq install -y build-essential python-software-properties s3cmd git-core linux-image-extra-`uname -r` bridge-utils bsdtar lxc wget ruby python-dev libxml2-dev python-setuptools redis-server supervisor
 echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 apt-get -qq update
 DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes lxc-docker

--- a/provision-aws.sh
+++ b/provision-aws.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+APP_DIR=/opt/app
+VE_ROOT=/opt/ve
+VE_DIR=$VE_ROOT/shipyard
+NODE_URL='http://nodejs.org/dist/v0.10.12/node-v0.10.12.tar.gz'
+GIT_RECEIVER_URL='https://raw.github.com/ehazlett/gitreceive/master/gitreceive'
+
+if [ -e "/etc/.provisioned" ] ; then
+    echo "VM already provisioned.  Remove /etc/.provisioned to force"
+    exit 0
+fi
+
+apt-get -qq update
+DEBIAN_FRONTEND=noninteractive apt-get -qq install -y python-software-properties s3cmd git-core linux-image-extra-`uname -r` bridge-utils bsdtar lxc wget ruby python-dev libxml2-dev python-setuptools redis-server supervisor
+echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
+apt-get -qq update
+DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes lxc-docker
+# edit docker upstart to listen on tcp
+sed -i 's/\/usr\/bin\/docker.*/\/usr\/bin\/docker -d -H tcp:\/\/0.0.0.0:4243 -H unix:\/\/\/var\/run\/docker\.sock/g' /etc/init/docker.conf
+service docker restart
+
+mkdir -p $VE_ROOT
+
+easy_install pip
+pip install virtualenv
+
+# install hipache
+if [ ! -e "/usr/local/bin/node" ] ; then
+    cd /tmp
+    wget $NODE_URL -O nodejs.tar.gz
+    tar zxf nodejs.tar.gz
+    cd node-*
+    ./configure ; make ; make install
+fi
+
+npm install git+http://github.com/ehazlett/hipache.git -g
+
+cat << EOF > /etc/hipache.config.json
+{
+    "server": {
+        "accessLog": "/var/log/hipache_access.log",
+        "port": 80,
+        "workers": 5,
+        "maxSockets": 100,
+        "deadBackendTTL": 30
+    },
+    "redisHost": "127.0.0.1",
+    "redisPort": 6379
+}
+EOF
+# install gitreceiver
+cd /tmp
+wget $GIT_RECEIVER_URL -O /usr/local/bin/gitreceive --no-check-certificate
+chmod +x /usr/local/bin/gitreceive
+if [ ! -e "/home/git" ]; then
+    /usr/local/bin/gitreceive init
+fi
+
+# app
+virtualenv --no-site-packages $VE_DIR
+
+cd $APP_DIR
+$VE_DIR/bin/pip install -r requirements.txt
+chown -R ubuntu $VE_DIR
+
+# bashrc
+UBUNTU_BASHRC=/home/ubuntu/.bashrc
+if [ "`grep \"source /opt/ve\" $UBUNTU_BASHRC`" = "" ]; then
+    echo "source $VE_DIR/bin/activate" >> $UBUNTU_BASHRC
+    echo "alias pm='python manage.py \$*'" >> $UBUNTU_BASHRC
+    echo "alias pmr='python manage.py runserver 0.0.0.0:8000\$*'" >> $UBUNTU_BASHRC
+    echo "alias pmq='python manage.py celery worker -B --scheduler=djcelery.schedulers.DatabaseScheduler -E\$*'" >> $UBUNTU_BASHRC
+    echo "echo ''" >> $UBUNTU_BASHRC
+    echo "cd $APP_DIR" >> $UBUNTU_BASHRC
+fi
+
+# install go
+if [ ! -e "/usr/local/go" ] ; then
+    wget -O /tmp/go.tar.gz http://go.googlecode.com/files/go1.1.2.linux-amd64.tar.gz
+    cd /usr/local ;  tar xzf /tmp/go.tar.gz
+    rm -rf /tmp/go.tar.gz
+fi
+
+cat << EOF > /etc/environment
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/local/go/bin"
+EOF
+
+cat << EOF > /etc/supervisor/conf.d/shipyard.conf
+[program:hipache]
+directory=/tmp
+command=hipache -c /etc/hipache.config.json
+user=root
+autostart=true
+autorestart=true
+
+EOF
+
+supervisorctl update
+
+touch /etc/.provisioned

--- a/provision-aws.sh
+++ b/provision-aws.sh
@@ -3,7 +3,6 @@
 APP_DIR=/opt/apps
 VE_ROOT=/opt/ve
 VE_DIR=$VE_ROOT/shipyard
-NODE_URL='http://nodejs.org/dist/v0.10.12/node-v0.10.12.tar.gz'
 GIT_RECEIVER_URL='https://raw.github.com/ehazlett/gitreceive/master/gitreceive'
 
 if [ -e "/etc/.provisioned" ] ; then
@@ -13,26 +12,26 @@ fi
 
 apt-get -qq update
 DEBIAN_FRONTEND=noninteractive apt-get -qq install -y build-essential python-software-properties s3cmd git-core linux-image-extra-`uname -r` bridge-utils bsdtar lxc wget ruby python-dev libxml2-dev python-setuptools redis-server supervisor
+
+# Install Node.js
+# from https://chrislea.com/2013/03/15/upgrading-from-node-js-0-8-x-to-0-10-0-from-my-ppa/
+echo deb http://ppa.launchpad.net/chris-lea/node.js/ubuntu raring main > /etc/apt/sources.list.d/nodejs.list
+echo deb-src http://ppa.launchpad.net/chris-lea/node.js/ubuntu raring main >> /etc/apt/sources.list.d/nodejs.list
+
+# Add the Docker sources
 echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 apt-get -qq update
-DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes lxc-docker
-# edit docker upstart to listen on tcp
+
+echo "Install docker and nodejs"
+DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --force-yes lxc-docker nodejs
+
+echo "Edit docker upstart to listen on tcp"
 sed -i 's/\/usr\/bin\/docker.*/\/usr\/bin\/docker -d -H tcp:\/\/0.0.0.0:4243 -H unix:\/\/\/var\/run\/docker\.sock/g' /etc/init/docker.conf
 service docker restart
 
 mkdir -p $VE_ROOT
 
 easy_install pip
-pip install virtualenv
-
-# install hipache
-if [ ! -e "/usr/local/bin/node" ] ; then
-    cd /tmp
-    wget $NODE_URL -O nodejs.tar.gz
-    tar zxf nodejs.tar.gz
-    cd node-*
-    ./configure ; make ; make install
-fi
 pip install virtualenv uwsgi
 
 npm install git+http://github.com/ehazlett/hipache.git -g

--- a/provision-aws.sh
+++ b/provision-aws.sh
@@ -33,6 +33,7 @@ if [ ! -e "/usr/local/bin/node" ] ; then
     cd node-*
     ./configure ; make ; make install
 fi
+pip install virtualenv uwsgi
 
 npm install git+http://github.com/ehazlett/hipache.git -g
 

--- a/provision-aws.sh
+++ b/provision-aws.sh
@@ -75,13 +75,7 @@ cat << EOF > /etc/environment
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/local/go/bin"
 EOF
 
-cat << EOF > /etc/supervisor/conf.d/shipyard.conf
-[program:hipache]
-directory=/tmp
-command=hipache -c /etc/hipache.config.json
-user=root
-autostart=true
-autorestart=true
+cp $APP_DIR/shipyard/.docker/supervisor.conf /etc/supervisor/conf.d/shipyard.conf
 
 EOF
 

--- a/provision-aws.sh
+++ b/provision-aws.sh
@@ -36,20 +36,9 @@ pip install virtualenv uwsgi
 
 npm install git+http://github.com/ehazlett/hipache.git -g
 
-cat << EOF > /etc/hipache.config.json
-{
-    "server": {
-        "accessLog": "/var/log/hipache_access.log",
-        "port": 80,
-        "workers": 5,
-        "maxSockets": 100,
-        "deadBackendTTL": 30
-    },
-    "redisHost": "127.0.0.1",
-    "redisPort": 6379
-}
-EOF
-# install gitreceiver
+cp $APP_DIR/shipyard/.docker/hipache.config.json /etc/hipache.config.json
+
+echo "Install gitreceiver"
 cd /tmp
 wget $GIT_RECEIVER_URL -O /usr/local/bin/gitreceive --no-check-certificate
 chmod +x /usr/local/bin/gitreceive

--- a/provision-aws.sh
+++ b/provision-aws.sh
@@ -53,6 +53,11 @@ cd $APP_DIR
 $VE_DIR/bin/pip install -r requirements.txt
 chown -R ubuntu $VE_DIR
 
+echo "Run syncdb, migrate and create superuser"
+cd $APP_DIR/shipyard && $VE_DIR/bin/python manage.py syncdb --noinput
+cd $APP_DIR/shipyard && $VE_DIR/bin/python manage.py migrate
+cd $APP_DIR/shipyard && $VE_DIR/bin/python manage.py update_admin_user --username=admin --password=shipyard
+
 # bashrc
 UBUNTU_BASHRC=/home/ubuntu/.bashrc
 if [ "`grep \"source /opt/ve\" $UBUNTU_BASHRC`" = "" ]; then

--- a/provision-aws.sh
+++ b/provision-aws.sh
@@ -82,7 +82,8 @@ EOF
 
 cp $APP_DIR/shipyard/.docker/supervisor.conf /etc/supervisor/conf.d/shipyard.conf
 
-EOF
+echo "Stop the Redis server so we can control it from Supervisor"
+service redis-server stop
 
 supervisorctl update
 


### PR DESCRIPTION
Rather than touching the existing Vagrantfile, I chose to make a new Vagrantfile-aws. You may want to incorporate these changes into the existing Vagrantfile, so there's only one file to maintain.

Similarly, there is a special provision-aws.sh script which differs from provision.sh, but could probably be incorporated into provision.sh, so there's only one file to maintain. The provision-aws.sh script borrowed from Dockerfile, so as to match the conventions used there.

The README explains a few other steps to get things working smoothly on AWS.
