### PR TITLE
Reorder apps so applications follows containers.

### DIFF
--- a/shipyard/settings.py
+++ b/shipyard/settings.py
@@ -167,8 +167,8 @@ INSTALLED_APPS = (
     'tastypie',
     'shipyard',
     'accounts',
-    'applications',
     'containers',
+    'applications',
     'images',
     'hosts',
 )


### PR DESCRIPTION
Today I switched from using the default local sqlite db to a remote PostgreSQL server. The south migrations failed because Applications has a dependency on Containers. 

```
FATAL ERROR - The following SQL query failed: ALTER TABLE "applications_application_containers" ADD CONSTRAINT "container_id_refs_id_f450c8a8" FOREIGN KEY ("container_id") REFERENCES "containers_container" ("id") DEFERRABLE INITIALLY DEFERRED;
The error was: relation "containers_container" does not exist

Error in migration: applications:0001_initial
DatabaseError: relation "containers_container" does not exist
```

By re-ordering the apps in the settings.py, South now performs migrations in the correct order. I'm not sure if this is only specific to PostgreSQL because of the way it handles contraints, or if this bug applies to any migrations run on brand new empty databases.
