### PR TITLE
Downgrade Node.js back to v8.26 for hipache websocket issue.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM base
 MAINTAINER Evan Hazlett "ejhazlett@gmail.com"
 RUN apt-get -qq update
 RUN apt-get install -y python-dev python-setuptools libxml2-dev libxslt-dev libmysqlclient-dev supervisor redis-server git-core wget make g++
-RUN wget http://nodejs.org/dist/v0.10.12/node-v0.10.12.tar.gz -O /tmp/node.tar.gz
+RUN wget http://nodejs.org/dist/v0.8.26/node-v0.8.26.tar.gz -O /tmp/node.tar.gz
 RUN (cd /tmp && tar zxf node.tar.gz && cd node-* && ./configure ; make install)
 RUN npm install git+http://github.com/ehazlett/hipache.git -g
 ADD .docker/hipache.config.json /etc/hipache.config.json


### PR DESCRIPTION
As noted in this hipache issue - https://github.com/dotcloud/hipache/issues/24

I am unable to get websockets to work properly with the 0.10.x releases of Node. Using 0.8.26 works well.
