### PR TITLE
Docker 0.6.5+ port spec changes

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -38,6 +38,7 @@ class ApplicationForm(forms.ModelForm):
                 'name',
                 'description',
                 'domain_name',
+                'host_interface',
                 'backend_port',
                 'protocol',
                 Field('containers', size=container_list_length),
@@ -58,16 +59,22 @@ class ApplicationForm(forms.ModelForm):
             self._errors['containers'] = self.error_class([msg])
 
         port = data.get('backend_port')
+        interface = data.get('host_interface') or '0.0.0.0'
         for c in data.get('containers', []):
             port_proto = "{0}/tcp".format(port)
-            if not port_proto in c.get_ports():
+            container_ports = c.get_ports()
+            if not port_proto in container_ports:
                 msg = _(u'Port %s is not available on the selected containers.' % port_proto)
                 self._errors['backend_port'] = self.error_class([msg])
+            if not container_ports.get(port_proto).get(interface):
+                msg = _(u'Port %s is not bound to the interface %s on the selected containers.' % (port_proto, interface))
+                self._errors['host_interface'] = self.error_class([msg])
+
         return data
 
     class Meta:
         model = Application
-        fields = ('name', 'description', 'domain_name', 'backend_port',
+        fields = ('name', 'description', 'domain_name', 'host_interface', 'backend_port',
             'protocol', 'containers')
 
 class EditApplicationForm(forms.Form):
@@ -75,6 +82,7 @@ class EditApplicationForm(forms.Form):
     name = forms.CharField(required=True)
     description = forms.CharField(required=False)
     domain_name = forms.CharField(required=True)
+    host_interface = forms.CharField(required=False)
     backend_port = forms.CharField(required=True)
     protocol = forms.ChoiceField(required=True)
 

--- a/applications/forms.py
+++ b/applications/forms.py
@@ -59,8 +59,9 @@ class ApplicationForm(forms.ModelForm):
 
         port = data.get('backend_port')
         for c in data.get('containers', []):
-            if not port in c.get_ports():
-                msg = _(u'Port %s is not available on the selected containers.' % port)
+            port_proto = "{0}/tcp".format(port)
+            if not port_proto in c.get_ports():
+                msg = _(u'Port %s is not available on the selected containers.' % port_proto)
                 self._errors['backend_port'] = self.error_class([msg])
         return data
 

--- a/applications/migrations/0007_auto__add_field_application_host_interface.py
+++ b/applications/migrations/0007_auto__add_field_application_host_interface.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Application.host_interface'
+        db.add_column(u'applications_application', 'host_interface',
+                      self.gf('django.db.models.fields.CharField')(max_length=128, null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Application.host_interface'
+        db.delete_column(u'applications_application', 'host_interface')
+
+
+    models = {
+        u'applications.application': {
+            'Meta': {'object_name': 'Application'},
+            'backend_port': ('django.db.models.fields.CharField', [], {'max_length': '5', 'null': 'True'}),
+            'containers': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['containers.Container']", 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'domain_name': ('django.db.models.fields.CharField', [], {'max_length': '96', 'unique': 'True', 'null': 'True'}),
+            'host_interface': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'protocol': ('django.db.models.fields.CharField', [], {'default': "'http'", 'max_length': '6', 'null': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'default': "'f4e4d3b55756482fb1c21b95ebce24af'", 'max_length': '36', 'unique': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'containers.container': {
+            'Meta': {'object_name': 'Container'},
+            'container_id': ('django.db.models.fields.CharField', [], {'max_length': '96', 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'host': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['containers.Host']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_running': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'meta': ('django.db.models.fields.TextField', [], {'default': "'{}'", 'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'protected': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'containers.host': {
+            'Meta': {'object_name': 'Host'},
+            'enabled': ('django.db.models.fields.NullBooleanField', [], {'default': 'True', 'null': 'True', 'blank': 'True'}),
+            'hostname': ('django.db.models.fields.CharField', [], {'max_length': '128', 'unique': 'True', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64', 'unique': 'True', 'null': 'True'}),
+            'port': ('django.db.models.fields.SmallIntegerField', [], {'default': '4243', 'null': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['applications']

--- a/applications/models.py
+++ b/applications/models.py
@@ -22,6 +22,8 @@ class Application(models.Model):
     description = models.TextField(null=True, blank=True)
     domain_name = models.CharField(max_length=96, null=True,
         unique=True)
+    host_interface = models.CharField(max_length=128, null=True, blank=True,
+        help_text='Host interface your port is bound to or leave blank for default')
     backend_port = models.CharField(max_length=5, null=True)
     protocol = models.CharField(max_length=6, null=True,
         default='http', choices=PROTOCOL_CHOICES)

--- a/containers/forms.py
+++ b/containers/forms.py
@@ -46,7 +46,7 @@ class CreateContainerForm(forms.Form):
         help_text='Memory in MB')
     environment = forms.CharField(required=False,
         help_text='key=value space separated pairs')
-    ports = forms.CharField(required=False, help_text='space separated')
+    ports = forms.CharField(required=False, help_text='space separated (i.e. 8000 8001:8001 127.0.0.1:80:80 )')
     volume = forms.CharField(required=False, help_text='container volume (i.e. /mnt/volume)')
     volumes_from = forms.CharField(required=False,
         help_text='mount volumes from specified container')

--- a/containers/templates/containers/container_details.html
+++ b/containers/templates/containers/container_details.html
@@ -151,40 +151,35 @@
                     <span class="panel-title">{% trans 'Ports' %}</span>
                 </div>
                 <div class="panel-body">
-                    {% with net=container.get_meta.NetworkSettings %}
-                    {% with tcp=net.PortMapping.Tcp %}
-                    {% with udp=net.PortMapping.Udp %}
-                    {% if tcp or udp %}
+                    {% with ports=container.get_ports %}
+                    {% if ports %}
                     <table class="table table-hover">
                         <thead>
                             <tr>
-                                <th>{% trans 'Protocol' %}</th>
                                 <th>{% trans 'Port' %}</th>
+                                <th>{% trans 'Host Interface' %}</th>
                                 <th>{% trans 'Mapping' %}</th>
                             </tr>
                         </thead>
                         <tbody>
-                            {% for k,v in tcp.items %}
+                            {% for port,host_list in ports.items %}
+                            {% for interface,mapping in host_list.items %}
                             <tr>
-                                <td>TCP</td>
-                                <td>{{k}}</td>
-                                <td>{{v|container_port_link:container.host.name|safe}}</td>
+                                <td>{{port}}</td>
+                                <td>{{interface}}</td>
+                                <td>
+                                  <a target="_blank" href="{{interface|container_host_url:container.host.hostname}}:{{mapping}}">
+                                  {{mapping}}
+                                  </a>
+                                </td>
                             </tr>
                             {% endfor %}
-                            {% for k,v in udp.items %}
-                            <tr>
-                                <td>UDP</td>
-                                <td>{{k}}</td>
-                                <td>{{v}}</td>
-                            </tr>
                             {% endfor %}
                         </tbody>
                     </table>
                     {% else %}
                     <span class="text-muted">{% trans 'No port mappings' %}</span>
                     {% endif %}
-                    {% endwith %}
-                    {% endwith %}
                     {% endwith %}
                 </div>
             </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-celery==3.0.23
 django-crispy-forms==1.4.0
 django-redis==3.3
 django-tastypie==0.9.16
-docker-py==0.2.2
+-e git+https://github.com/dotcloud/docker-py@14946ed56bfc6da252496526d650b586f86a29dc#egg=docker_py-dev
 kombu==2.5.14
 mimeparse==0.1.3
 python-dateutil==2.1

--- a/shipyard/templatetags/shipyard.py
+++ b/shipyard/templatetags/shipyard.py
@@ -58,6 +58,25 @@ def container_port_link(port, host):
     return ret
 
 @register.filter
+def container_host_url(interface, hostname):
+    """
+    Returns exposed interface URL, replacing default 0.0.0.0
+    with container hostname as url
+
+    :param interface: Port interface
+    :param hostname: Container host name
+
+    """
+    if interface == '0.0.0.0':
+        if 'unix' in hostname:
+            host_url = '127.0.0.1'
+        else:
+            host_url = hostname
+    else:
+        host_url = interface
+    return 'http://{0}'.format(host_url)
+
+@register.filter
 @stringfilter
 def container_memory_to_mb(value):
     """

--- a/shipyard/utils.py
+++ b/shipyard/utils.py
@@ -60,9 +60,10 @@ def update_hipache(app_id=None):
             # add upstreams
             for c in app.containers.all():
                 port_proto = "{0}/tcp".format(app.backend_port)
-                port = c.get_ports()[port_proto]['0.0.0.0']
-                upstream = '{0}://{1}:{2}'.format(app.protocol, c.host.hostname,
-                    port)
+                host_interface = app.host_interface or '0.0.0.0'
+                hostname = c.host.hostname if host_interface == '0.0.0.0' else host_interface
+                port = c.get_ports()[port_proto][host_interface]
+                upstream = '{0}://{1}:{2}'.format(app.protocol, hostname, port)
                 pipe.rpush(domain_key, upstream)
             pipe.execute()
             return True

--- a/shipyard/utils.py
+++ b/shipyard/utils.py
@@ -59,7 +59,8 @@ def update_hipache(app_id=None):
             pipe.rpush(domain_key, app.id)
             # add upstreams
             for c in app.containers.all():
-                port = c.get_ports()[app.backend_port]
+                port_proto = "{0}/tcp".format(app.backend_port)
+                port = c.get_ports()[port_proto]['0.0.0.0']
                 upstream = '{0}://{1}:{2}'.format(app.protocol, c.host.hostname,
                     port)
                 pipe.rpush(domain_key, upstream)


### PR DESCRIPTION
This fixes all issues for docker host v0.6.5 and above. If the version is below that, then the port field on the create_container form does not work at all. This is because I switched to the dev version of docker-py which doesn't have backwards compatible port specifications.
