### PR TITLE
Respecting Entrypoints

### DIFF
--- a/containers/templates/containers/container_details.html
+++ b/containers/templates/containers/container_details.html
@@ -87,9 +87,9 @@
                 </dl>
                 <dl class="dl-horizontal">
                     <dt>{% trans 'Command' %}</dt>
-                    <dd>{% if c.get_meta.Config.Entrypoint %}{{c.get_meta.Config.Entrypoint|join:" "}}
+                    <dd>{% if container.get_meta.Config.Entrypoint %}{{container.get_meta.Config.Entrypoint|join:" "}}
                         {% else %}
-                        {% if c.get_meta.Config.Cmd %}{{c.get_meta.Config.Cmd|join:" "}}{% endif %}
+                        {% if container.get_meta.Config.Cmd %}{{container.get_meta.Config.Cmd|join:" "}}{% endif %}
                         {% endif %}
                     </dd>
 

--- a/containers/templates/containers/container_details.html
+++ b/containers/templates/containers/container_details.html
@@ -87,7 +87,12 @@
                 </dl>
                 <dl class="dl-horizontal">
                     <dt>{% trans 'Command' %}</dt>
-                    <dd>{% if container.get_meta.Cmd %}{{container.get_meta.Config.Cmd|join:" "}}{% endif %}</dd>
+                    <dd>{% if c.get_meta.Config.Entrypoint %}{{c.get_meta.Config.Entrypoint|join:" "}}
+                        {% else %}
+                        {% if c.get_meta.Config.Cmd %}{{c.get_meta.Config.Cmd|join:" "}}{% endif %}
+                        {% endif %}
+                    </dd>
+
                 </dl>
                 <dl class="dl-horizontal">
                     <dt>{% trans 'IP' %}</dt>

--- a/containers/templates/containers/index.html
+++ b/containers/templates/containers/index.html
@@ -31,7 +31,11 @@
                     <td><a href="{% url 'containers.views.container_details' container_id=c.container_id %}" class="container-info" data-container-id="{{c.container_id}}">{{c.get_short_id}}</a></td>
                     <td>{{c.description}}</td>
                     <td>{{c.get_meta.Config.Image}}</td>
-                    <td>{% if c.get_meta.Config.Cmd %}{{c.get_meta.Config.Cmd|join:" "}}{% endif %}</td>
+                    <td>{% if c.get_meta.Config.Entrypoint %}{{c.get_meta.Config.Entrypoint|join:" "}}
+                        {% else %}
+                        {% if c.get_meta.Config.Cmd %}{{c.get_meta.Config.Cmd|join:" "}}{% endif %}
+                        {% endif %}
+                    </td>
                     <td>{{c.host.name}}</td>
                     <td>
                         <div class="btn-group">


### PR DESCRIPTION
Fixes will show Entrypoints also.
From now only Cmd is shown or nothing if Cmd is not defined.
This ignores Entrypoints.
