### PR TITLE
extensions

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -50,6 +50,9 @@ func main() {
 		serviceKeysListCommand,
 		serviceKeyCreateCommand,
 		serviceKeyRemoveCommand,
+		extensionsCommand,
+		addExtensionCommand,
+		removeExtensionCommand,
 		infoCommand,
 		eventsCommand,
 	}

--- a/cli/extensions.go
+++ b/cli/extensions.go
@@ -85,7 +85,7 @@ func addExtensionAction(c *cli.Context) {
 	fmt.Printf("configuring %s (%s for more info)\n", ext.Name, ext.Url)
 	// check for configuration
 	for _, pe := range ext.Config.PromptEnvironment {
-		fmt.Printf("enter value for container environment variable \"%s\": ", pe)
+		fmt.Printf("enter value for container environment variable %s: ", pe)
 		b := bufio.NewReader(os.Stdin)
 		r, _, err := b.ReadLine()
 		if err != nil {
@@ -94,13 +94,16 @@ func addExtensionAction(c *cli.Context) {
 		env[pe] = string(r)
 	}
 	for _, pa := range ext.Config.PromptArgs {
-		fmt.Printf("enter value for container argument \"%s\": ", pa)
+		fmt.Printf("enter value for container argument %s: ", pa)
 		b := bufio.NewReader(os.Stdin)
 		r, _, err := b.ReadLine()
 		if err != nil {
 			logger.Fatalf("unable to parse input: %s", err)
 		}
-		arg := fmt.Sprintf("%s=%s", pa, r)
+		arg := string(r)
+		if pa != "" {
+			arg = fmt.Sprintf("%s=%s", pa, r)
+		}
 		args = append(args, arg)
 	}
 	ext.Config.Environment = env

--- a/cli/extensions.go
+++ b/cli/extensions.go
@@ -48,6 +48,16 @@ var addExtensionCommand = cli.Command{
 			Name:  "url",
 			Usage: "extension config url",
 		},
+		cli.StringSliceFlag{
+			Name:  "env",
+			Usage: "environment variables (key=value pairs)",
+			Value: &cli.StringSlice{},
+		},
+		cli.StringSliceFlag{
+			Name:  "arg",
+			Usage: "arguments",
+			Value: &cli.StringSlice{},
+		},
 	},
 }
 
@@ -61,14 +71,18 @@ func addExtensionAction(c *cli.Context) {
 	if extUrl == "" {
 		logger.Fatalf("you must specify an extension config url")
 	}
+	env := parseEnvironmentVariables(c.StringSlice("env"))
+	args := c.StringSlice("arg")
 	resp, err := http.Get(extUrl)
 	if err != nil {
 		logger.Fatalf("unable to get extension config: %s", err)
 	}
 	var ext *shipyard.Extension
 	if err := json.NewDecoder(resp.Body).Decode(&ext); err != nil {
-
+		logger.Fatalf("error parsing extension config: %s", err, err)
 	}
+	ext.Environment = env
+	ext.Args = args
 	if err := m.AddExtension(ext); err != nil {
 		logger.Fatalf("error adding extension: %s", err)
 	}

--- a/cli/extensions.go
+++ b/cli/extensions.go
@@ -81,8 +81,8 @@ func addExtensionAction(c *cli.Context) {
 	if err := json.NewDecoder(resp.Body).Decode(&ext); err != nil {
 		logger.Fatalf("error parsing extension config: %s", err, err)
 	}
-	ext.Environment = env
-	ext.Args = args
+	ext.Config.Environment = env
+	ext.Config.Args = args
 	if err := m.AddExtension(ext); err != nil {
 		logger.Fatalf("error adding extension: %s", err)
 	}

--- a/cli/extensions.go
+++ b/cli/extensions.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -80,6 +81,27 @@ func addExtensionAction(c *cli.Context) {
 	var ext *shipyard.Extension
 	if err := json.NewDecoder(resp.Body).Decode(&ext); err != nil {
 		logger.Fatalf("error parsing extension config: %s", err, err)
+	}
+	fmt.Printf("configuring %s (%s for more info)\n", ext.Name, ext.Url)
+	// check for configuration
+	for _, pe := range ext.Config.PromptEnvironment {
+		fmt.Printf("enter value for container environment variable \"%s\": ", pe)
+		b := bufio.NewReader(os.Stdin)
+		r, _, err := b.ReadLine()
+		if err != nil {
+			logger.Fatalf("unable to parse input: %s", err)
+		}
+		env[pe] = string(r)
+	}
+	for _, pa := range ext.Config.PromptArgs {
+		fmt.Printf("enter value for container argument \"%s\": ", pa)
+		b := bufio.NewReader(os.Stdin)
+		r, _, err := b.ReadLine()
+		if err != nil {
+			logger.Fatalf("unable to parse input: %s", err)
+		}
+		arg := fmt.Sprintf("%s=%s", pa, r)
+		args = append(args, arg)
 	}
 	ext.Config.Environment = env
 	ext.Config.Args = args

--- a/cli/extensions.go
+++ b/cli/extensions.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"text/tabwriter"
+
+	"github.com/codegangsta/cli"
+	"github.com/shipyard/shipyard"
+	"github.com/shipyard/shipyard/client"
+)
+
+var extensionsCommand = cli.Command{
+	Name:   "extensions",
+	Usage:  "show extensions",
+	Action: extensionsAction,
+}
+
+func extensionsAction(c *cli.Context) {
+	cfg, err := loadConfig()
+	if err != nil {
+		logger.Fatal(err)
+	}
+	m := client.NewManager(cfg)
+	exts, err := m.Extensions()
+	if err != nil {
+		logger.Fatalf("error getting extensions: %s", err)
+	}
+	if len(exts) == 0 {
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
+	fmt.Fprintln(w, "ID\tName\tVersion\tAuthor\tImage\tUrl\tDescription")
+	for _, e := range exts {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.ID, e.Name, e.Version, e.Author, e.Image, e.Url, e.Description)
+	}
+	w.Flush()
+}
+
+var addExtensionCommand = cli.Command{
+	Name:   "add-extension",
+	Usage:  "add extension",
+	Action: addExtensionAction,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "url",
+			Usage: "extension config url",
+		},
+	},
+}
+
+func addExtensionAction(c *cli.Context) {
+	cfg, err := loadConfig()
+	if err != nil {
+		logger.Fatal(err)
+	}
+	m := client.NewManager(cfg)
+	extUrl := c.String("url")
+	if extUrl == "" {
+		logger.Fatalf("you must specify an extension config url")
+	}
+	resp, err := http.Get(extUrl)
+	if err != nil {
+		logger.Fatalf("unable to get extension config: %s", err)
+	}
+	var ext *shipyard.Extension
+	if err := json.NewDecoder(resp.Body).Decode(&ext); err != nil {
+
+	}
+	if err := m.AddExtension(ext); err != nil {
+		logger.Fatalf("error adding extension: %s", err)
+	}
+	fmt.Printf("added extension name=%s version=%s\n", ext.Name, ext.Version)
+}
+
+var removeExtensionCommand = cli.Command{
+	Name:        "remove-extension",
+	Usage:       "remove an extension",
+	Description: "remove-extension <id> [id]",
+	Action:      removeExtensionAction,
+}
+
+func removeExtensionAction(c *cli.Context) {
+	cfg, err := loadConfig()
+	if err != nil {
+		logger.Fatal(err)
+	}
+	m := client.NewManager(cfg)
+	extIds := c.Args()
+	if len(extIds) == 0 {
+		return
+	}
+	for _, id := range extIds {
+		if err := m.RemoveExtension(id); err != nil {
+			logger.Fatalf("error removing extension: %s", err)
+		}
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -331,3 +331,33 @@ func (m *Manager) RemoveServiceKey(key *shipyard.ServiceKey) error {
 	}
 	return nil
 }
+
+func (m *Manager) Extensions() ([]*shipyard.Extension, error) {
+	exts := []*shipyard.Extension{}
+	resp, err := m.doRequest("/api/extensions", "GET", 200, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&exts); err != nil {
+		return nil, err
+	}
+	return exts, nil
+}
+
+func (m *Manager) AddExtension(ext *shipyard.Extension) error {
+	b, err := json.Marshal(ext)
+	if err != nil {
+		return err
+	}
+	if _, err := m.doRequest("/api/extensions", "POST", 204, b); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) RemoveExtension(id string) error {
+	if _, err := m.doRequest(fmt.Sprintf("/api/extensions/%s", id), "DELETE", 204, nil); err != nil {
+		return err
+	}
+	return nil
+}

--- a/controller/main.go
+++ b/controller/main.go
@@ -488,6 +488,7 @@ func deleteExtension(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	logger.Infof("removed extension %s", id)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/controller/manager/manager.go
+++ b/controller/manager/manager.go
@@ -557,15 +557,17 @@ func (m *Manager) RegisterExtension(ext *shipyard.Extension) error {
 	}
 	ext.Config.Environment["_SHIPYARD_EXTENSION"] = ext.ID
 	image := &citadel.Image{
-		Name:        ext.Image,
-		Cpus:        ext.Config.Cpus,
-		Memory:      ext.Config.Memory,
-		Environment: ext.Config.Environment,
-		Args:        ext.Config.Args,
-		Volumes:     ext.Config.Volumes,
-		BindPorts:   ext.Config.Ports,
-		Labels:      []string{},
-		Type:        "service",
+		Name:          ext.Image,
+		ContainerName: ext.Config.ContainerName,
+		Cpus:          ext.Config.Cpus,
+		Memory:        ext.Config.Memory,
+		Environment:   ext.Config.Environment,
+		Args:          ext.Config.Args,
+		Volumes:       ext.Config.Volumes,
+		VolumesFrom:   ext.Config.VolumesFrom,
+		BindPorts:     ext.Config.Ports,
+		Labels:        []string{},
+		Type:          "service",
 	}
 	if ext.Config.DeployPerEngine {
 		engs := m.clusterManager.Engines()

--- a/controller/manager/manager.go
+++ b/controller/manager/manager.go
@@ -544,7 +544,7 @@ func (m *Manager) SaveExtension(ext *shipyard.Extension) error {
 }
 
 func (m *Manager) DeleteExtension(id string) error {
-	res, err := r.Table(tblNameRoles).Get(id).Delete().Run(m.session)
+	res, err := r.Table(tblNameExtensions).Get(id).Delete().Run(m.session)
 	if err != nil {
 		return err
 	}

--- a/controller/manager/manager.go
+++ b/controller/manager/manager.go
@@ -622,7 +622,6 @@ func (m *Manager) RegisterExtension(ext *shipyard.Extension) error {
 		Environment:   ext.Config.Environment,
 		Args:          ext.Config.Args,
 		Volumes:       ext.Config.Volumes,
-		VolumesFrom:   ext.Config.VolumesFrom,
 		BindPorts:     ext.Config.Ports,
 		Labels:        []string{},
 		Type:          "service",

--- a/controller/manager/manager.go
+++ b/controller/manager/manager.go
@@ -549,7 +549,7 @@ func (m *Manager) SaveExtension(ext *shipyard.Extension) error {
 
 func (m *Manager) RegisterExtension(ext *shipyard.Extension) error {
 	if ext.Config.Environment != nil {
-		ext.Config.Environment["_shipyard_extension"] = ext.ID
+		ext.Config.Environment["_shipyard_extension"] = ext.Name
 	}
 	image := &citadel.Image{
 		Name:        ext.Image,
@@ -572,7 +572,7 @@ func (m *Manager) RegisterExtension(ext *shipyard.Extension) error {
 				logger.Errorf("error running %s for extension image %s: %s", image.Name, ext.Name, err)
 				return err
 			}
-			logger.Infof("started %s (%s) for extension %s", container.ID, image.Name, ext.Name)
+			logger.Infof("started %s (%s) for extension %s", container.ID[:8], image.Name, ext.Name)
 		}
 	} else {
 		container, err := m.clusterManager.Start(image, true)
@@ -580,7 +580,7 @@ func (m *Manager) RegisterExtension(ext *shipyard.Extension) error {
 			logger.Errorf("error running %s for extension image %s: %s", image.Name, ext.Name, err)
 			return err
 		}
-		logger.Infof("started %s (%s) for extension %s", container.ID, image.Name, ext.Name)
+		logger.Infof("started %s (%s) for extension %s", container.ID[:8], image.Name, ext.Name)
 	}
 	logger.Infof("registered extension name=%s version=%s author=%s", ext.Name, ext.Version, ext.Author)
 	return nil

--- a/controller/manager/manager.go
+++ b/controller/manager/manager.go
@@ -551,9 +551,11 @@ func (m *Manager) SaveExtension(ext *shipyard.Extension) error {
 }
 
 func (m *Manager) RegisterExtension(ext *shipyard.Extension) error {
-	if ext.Config.Environment != nil {
-		ext.Config.Environment["_SHIPYARD_EXTENSION"] = ext.ID
+	if ext.Config.Environment == nil {
+		env := make(map[string]string)
+		ext.Config.Environment = env
 	}
+	ext.Config.Environment["_SHIPYARD_EXTENSION"] = ext.ID
 	image := &citadel.Image{
 		Name:        ext.Image,
 		Cpus:        ext.Config.Cpus,

--- a/controller/manager/manager.go
+++ b/controller/manager/manager.go
@@ -562,6 +562,7 @@ func (m *Manager) RegisterExtension(ext *shipyard.Extension) error {
 		Memory:      ext.Config.Memory,
 		Environment: ext.Config.Environment,
 		Args:        ext.Config.Args,
+		Volumes:     ext.Config.Volumes,
 		BindPorts:   ext.Config.Ports,
 		Labels:      []string{},
 		Type:        "service",

--- a/controller/manager/manager.go
+++ b/controller/manager/manager.go
@@ -540,10 +540,31 @@ func (m *Manager) SaveExtension(ext *shipyard.Extension) error {
 	if err := m.SaveEvent(evt); err != nil {
 		return err
 	}
+	// register
+	if err := m.RegisterExtension(ext); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) RegisterExtension(ext *shipyard.Extension) error {
+	logger.Infof("registering extension name=%s version=%s author=%s", ext.Name, ext.Version, ext.Author)
+	return nil
+}
+
+func (m *Manager) UnregisterExtension(ext *shipyard.Extension) error {
+	logger.Infof("un-registering extension name=%s version=%s author=%s", ext.Name, ext.Version, ext.Author)
 	return nil
 }
 
 func (m *Manager) DeleteExtension(id string) error {
+	ext, err := m.Extension(id)
+	if err != nil {
+		return err
+	}
+	if err := m.UnregisterExtension(ext); err != nil {
+		return err
+	}
 	res, err := r.Table(tblNameExtensions).Get(id).Delete().Run(m.session)
 	if err != nil {
 		return err

--- a/extension.go
+++ b/extension.go
@@ -12,9 +12,9 @@ type (
 		Environment map[string]string `json:"environment,omitempty" gorethink:"environment,omitempty"`
 		Args        []string          `json:"args,omitempty" gorethink:"args,omitempty"`
 		Ports       []int             `json:"ports,omitempty" gorethink:"ports,omitempty"`
-		Config      *ExtensionConfig  `json:"config,omitempty" gorethink:"config,omitempty"`
+		Config      ExtensionConfig   `json:"config" gorethink:"config"`
 	}
 	ExtensionConfig struct {
-		DeployPerEngine bool `json:"deploy_per_engine,omitempty" gorethink:"deploy_per_engine,omitempty"`
+		DeployPerEngine bool `json:"deploy_per_engine" gorethink:"deploy_per_engine"`
 	}
 )

--- a/extension.go
+++ b/extension.go
@@ -20,7 +20,6 @@ type (
 		Environment       map[string]string `json:"environment,omitempty" gorethink:"environment"`
 		Args              []string          `json:"args,omitempty" gorethink:"args"`
 		Volumes           []string          `json:"volumes,omitempty" gorethink:"volumes"`
-		VolumesFrom       []string          `json:"volumes_from,omitempty" gorethink:"volumes_from"`
 		Ports             []*citadel.Port   `json:"ports,omitempty" gorethink:"ports"`
 		DeployPerEngine   bool              `json:"deploy_per_engine" gorethink:"deploy_per_engine"`
 		PromptArgs        []string          `json:"prompt_args,omitempty" gorethink:"prompt_args"`

--- a/extension.go
+++ b/extension.go
@@ -14,11 +14,13 @@ type (
 		Config      ExtensionConfig `json:"config" gorethink:"config"`
 	}
 	ExtensionConfig struct {
+		ContainerName     string            `json:"container_name,omitempty" gorethink:"container_name"`
 		Cpus              float64           `json:"cpus,omitempty" gorethink:"cpus"`
 		Memory            float64           `json:"memory,omitempty" gorethink:"memory"`
 		Environment       map[string]string `json:"environment,omitempty" gorethink:"environment"`
 		Args              []string          `json:"args,omitempty" gorethink:"args"`
 		Volumes           []string          `json:"volumes,omitempty" gorethink:"volumes"`
+		VolumesFrom       []string          `json:"volumes_from,omitempty" gorethink:"volumes_from"`
 		Ports             []*citadel.Port   `json:"ports,omitempty" gorethink:"ports"`
 		DeployPerEngine   bool              `json:"deploy_per_engine" gorethink:"deploy_per_engine"`
 		PromptArgs        []string          `json:"prompt_args,omitempty" gorethink:"prompt_args"`

--- a/extension.go
+++ b/extension.go
@@ -1,0 +1,19 @@
+package shipyard
+
+type (
+	Extension struct {
+		ID          string            `json:"id,omitempty" gorethink:"id,omitempty"`
+		Name        string            `json:"string,omitempty" gorethink:"name,omitempty"`
+		Author      string            `json:"author,omitempty" gorethink:"author,omitempty"`
+		Description string            `json:"description,omitempty" gorethink:"description,omitempty"`
+		Version     string            `json:"version,omitempty" gorethink:"version,omitempty"`
+		Url         string            `json:"url,omitempty" gorethink:"url,omitempty"`
+		Environment map[string]string `json:"environment,omitempty" gorethink:"environment,omitempty"`
+		Args        []string          `json:"args,omitempty" gorethink:"args,omitempty"`
+		Ports       []int             `json:"ports,omitempty" gorethink:"ports,omitempty"`
+		Config      *ExtensionConfig  `json:"config,omitempty" gorethink:"config,omitempty"`
+	}
+	ExtensionConfig struct {
+		DeployPerEngine bool `json:"deploy_per_engine,omitempty" gorethink:"deploy_per_engine,omitempty"`
+	}
+)

--- a/extension.go
+++ b/extension.go
@@ -5,20 +5,22 @@ import "github.com/citadel/citadel"
 type (
 	Extension struct {
 		ID          string          `json:"id,omitempty" gorethink:"id,omitempty"`
-		Name        string          `json:"name,omitempty" gorethink:"name,omitempty"`
-		Image       string          `json:"image,omitempty" gorethink:"image,omitempty"`
-		Author      string          `json:"author,omitempty" gorethink:"author,omitempty"`
-		Description string          `json:"description,omitempty" gorethink:"description,omitempty"`
-		Version     string          `json:"version,omitempty" gorethink:"version,omitempty"`
-		Url         string          `json:"url,omitempty" gorethink:"url,omitempty"`
+		Name        string          `json:"name,omitempty" gorethink:"name"`
+		Image       string          `json:"image,omitempty" gorethink:"image"`
+		Author      string          `json:"author,omitempty" gorethink:"author"`
+		Description string          `json:"description,omitempty" gorethink:"description"`
+		Version     string          `json:"version,omitempty" gorethink:"version"`
+		Url         string          `json:"url,omitempty" gorethink:"url"`
 		Config      ExtensionConfig `json:"config" gorethink:"config"`
 	}
 	ExtensionConfig struct {
-		Cpus            float64           `json:"cpus,omitempty" gorethink:"cpus,omitempty"`
-		Memory          float64           `json:"memory,omitempty" gorethink:"memory,omitempty"`
-		Environment     map[string]string `json:"environment,omitempty" gorethink:"environment,omitempty"`
-		Args            []string          `json:"args,omitempty" gorethink:"args,omitempty"`
-		Ports           []*citadel.Port   `json:"ports,omitempty" gorethink:"ports,omitempty"`
-		DeployPerEngine bool              `json:"deploy_per_engine" gorethink:"deploy_per_engine"`
+		Cpus              float64           `json:"cpus,omitempty" gorethink:"cpus"`
+		Memory            float64           `json:"memory,omitempty" gorethink:"memory"`
+		Environment       map[string]string `json:"environment,omitempty" gorethink:"environment"`
+		Args              []string          `json:"args,omitempty" gorethink:"args"`
+		Ports             []*citadel.Port   `json:"ports,omitempty" gorethink:"ports"`
+		DeployPerEngine   bool              `json:"deploy_per_engine" gorethink:"deploy_per_engine"`
+		PromptArgs        []string          `json:"prompt_args,omitempty" gorethink:"prompt_args"`
+		PromptEnvironment []string          `json:"prompt_env,omitempty" gorethink:"prompt_env"`
 	}
 )

--- a/extension.go
+++ b/extension.go
@@ -18,6 +18,7 @@ type (
 		Memory            float64           `json:"memory,omitempty" gorethink:"memory"`
 		Environment       map[string]string `json:"environment,omitempty" gorethink:"environment"`
 		Args              []string          `json:"args,omitempty" gorethink:"args"`
+		Volumes           []string          `json:"volumes,omitempty" gorethink:"volumes"`
 		Ports             []*citadel.Port   `json:"ports,omitempty" gorethink:"ports"`
 		DeployPerEngine   bool              `json:"deploy_per_engine" gorethink:"deploy_per_engine"`
 		PromptArgs        []string          `json:"prompt_args,omitempty" gorethink:"prompt_args"`

--- a/extension.go
+++ b/extension.go
@@ -3,7 +3,8 @@ package shipyard
 type (
 	Extension struct {
 		ID          string            `json:"id,omitempty" gorethink:"id,omitempty"`
-		Name        string            `json:"string,omitempty" gorethink:"name,omitempty"`
+		Name        string            `json:"name,omitempty" gorethink:"name,omitempty"`
+		Image       string            `json:"image,omitempty" gorethink:"image,omitempty"`
 		Author      string            `json:"author,omitempty" gorethink:"author,omitempty"`
 		Description string            `json:"description,omitempty" gorethink:"description,omitempty"`
 		Version     string            `json:"version,omitempty" gorethink:"version,omitempty"`

--- a/extension.go
+++ b/extension.go
@@ -1,20 +1,24 @@
 package shipyard
 
+import "github.com/citadel/citadel"
+
 type (
 	Extension struct {
-		ID          string            `json:"id,omitempty" gorethink:"id,omitempty"`
-		Name        string            `json:"name,omitempty" gorethink:"name,omitempty"`
-		Image       string            `json:"image,omitempty" gorethink:"image,omitempty"`
-		Author      string            `json:"author,omitempty" gorethink:"author,omitempty"`
-		Description string            `json:"description,omitempty" gorethink:"description,omitempty"`
-		Version     string            `json:"version,omitempty" gorethink:"version,omitempty"`
-		Url         string            `json:"url,omitempty" gorethink:"url,omitempty"`
-		Environment map[string]string `json:"environment,omitempty" gorethink:"environment,omitempty"`
-		Args        []string          `json:"args,omitempty" gorethink:"args,omitempty"`
-		Ports       []int             `json:"ports,omitempty" gorethink:"ports,omitempty"`
-		Config      ExtensionConfig   `json:"config" gorethink:"config"`
+		ID          string          `json:"id,omitempty" gorethink:"id,omitempty"`
+		Name        string          `json:"name,omitempty" gorethink:"name,omitempty"`
+		Image       string          `json:"image,omitempty" gorethink:"image,omitempty"`
+		Author      string          `json:"author,omitempty" gorethink:"author,omitempty"`
+		Description string          `json:"description,omitempty" gorethink:"description,omitempty"`
+		Version     string          `json:"version,omitempty" gorethink:"version,omitempty"`
+		Url         string          `json:"url,omitempty" gorethink:"url,omitempty"`
+		Config      ExtensionConfig `json:"config" gorethink:"config"`
 	}
 	ExtensionConfig struct {
-		DeployPerEngine bool `json:"deploy_per_engine" gorethink:"deploy_per_engine"`
+		Cpus            float64           `json:"cpus,omitempty" gorethink:"cpus,omitempty"`
+		Memory          float64           `json:"memory,omitempty" gorethink:"memory,omitempty"`
+		Environment     map[string]string `json:"environment,omitempty" gorethink:"environment,omitempty"`
+		Args            []string          `json:"args,omitempty" gorethink:"args,omitempty"`
+		Ports           []*citadel.Port   `json:"ports,omitempty" gorethink:"ports,omitempty"`
+		DeployPerEngine bool              `json:"deploy_per_engine" gorethink:"deploy_per_engine"`
 	}
 )


### PR DESCRIPTION
This adds initial support for "extension images".  This gives the controller the ability to add/remove/view extensions as well as control from the CLI.  Here is how it works:
1. user runs `add-extension --url http://host/path/to/shipyard.extension` to add an extension image to Shipyard
2. cli checks config for image arguments or environment variables that need values and prompts as needed
3. Shipyard "registers" extension and runs container(s)

Here is an example config (https://raw.githubusercontent.com/ehazlett/interlock/master/.shipyard.extension):

``` json
{
  "config": {
    "container_name": "shipyard_test",
    "deploy_per_engine": false,
    "volumes": [
      "/var/run/docker.sock:/tmp/docker.sock"
    ],
    "ports": [
      {
        "container_port": 8080,
        "port": 80,
        "proto": "tcp"
      }
    ],
    "memory": 32,
    "cpus": 0.1,
    "prompt_args": [
      "-shipyard-url",
      "-shipyard-service-key"
    ]
  },
  "url": "https://github.com/ehazlett/interlock",
  "description": "Application Router and Load Balancer",
  "author": "ehazlett",
  "version": "0.1",
  "image": "ehazlett/interlock",
  "name": "interlock"
}
```

The following fields are in place:
- `name`: creator designated name of extension
- `image`: Docker image that is used (must be on the Docker Hub)
- `version`: extension version
- `author`: extension author
- `description`: short description of extension
- `url`: url to extension source
- `config`: container run config
  - `container_name`: optional name of container
  - `cpus`: number of cpu shares
  - `memory`: amount of memory (in MB)
  - `volumes`: volumes to use in container
  - `ports`: ports published when container is started
  - `deploy_per_engine`: this will run a container for each engine in the cluster
  - `prompt_args`: array of container arguments that user is prompted to enter upon adding
  - `prompt_env`: array of container environment variables that user is prompted to enter upon adding

The `prompt_args` and `prompt_env` allow the extension to prompt the user for configuration values before launching.

Here is an example CLI add:

```
$> shipyard add-extension --url https://gist.githubusercontent.com/ehazlett/2b7d190498bd2c0f532e/raw/153208e860b1af414b229d85485508fb47e740e1/gistfile1.json
configuring test (https://github.com/ehazlett/go-demo for more info)
enter value for container environment variable "VERSION": test
enter value for container environment variable "URL": shipyard-project.com
added extension name=test version=0.1
```

You can test this out now with the `shipyard/shipyard:test` controller image and `shipyard/shipyard-cli:test` cli image.

This depends on citadel/citadel#66 and citadel/citadel#67

Feedback welcome :)
