### PR TITLE
dockerhub webhook support

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -537,7 +537,7 @@ func hubWebhook(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	logger.Infof("received webhook for %s", webhook.Repository.RepoName)
+	logger.Infof("received webhook notification for %s", webhook.Repository.RepoName)
 	if err := controllerManager.RedeployContainers(webhook.Repository.RepoName); err != nil {
 		logger.Errorf("error redeploying containers: %s", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/controller/manager/manager.go
+++ b/controller/manager/manager.go
@@ -729,6 +729,7 @@ func (m *Manager) RedeployContainers(image string) error {
 	if err != nil {
 		return err
 	}
+	deployed := false
 	for _, c := range containers {
 		if strings.Index(c.Image.Name, image) > -1 {
 			img = c.Image
@@ -746,7 +747,19 @@ func (m *Manager) RedeployContainers(image string) error {
 			if err != nil {
 				return err
 			}
+			deployed = true
 			logger.Infof("deployed updated container %s via webhook for %s", nc.ID[:8], image)
+		}
+	}
+	if deployed {
+		evt := &shipyard.Event{
+			Type:    "deploy",
+			Message: fmt.Sprintf("%s deployed", image),
+			Time:    time.Now(),
+			Tags:    []string{"deploy"},
+		}
+		if err := m.SaveEvent(evt); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/dockerhub/pushdata.go
+++ b/dockerhub/pushdata.go
@@ -1,0 +1,9 @@
+package dockerhub
+
+type (
+	PushData struct {
+		PushedAt int      `json:"pushed_at,omitempty"`
+		Images   []string `json:"images,omitempty"`
+		Pusher   string   `json:"pusher,omitempty"`
+	}
+)

--- a/dockerhub/repository.go
+++ b/dockerhub/repository.go
@@ -1,0 +1,21 @@
+package dockerhub
+
+type (
+	Repository struct {
+		Status          string `json:"status,omitempty"`
+		Description     string `json:"description,omitempty"`
+		IsTrusted       bool   `json:"is_trusted,omitempty"`
+		FullDescription string `json:"full_description,omitempty"`
+		RepoUrl         string `json:"repo_url,omitempty"`
+		Owner           string `json:"owner,omitempty"`
+		IsOfficial      bool   `json:"is_official,omitempty"`
+		IsPrivate       bool   `json:"is_private,omitempty"`
+		Name            string `json:"name,omitempty"`
+		Namespace       string `json:"namespace,omitempty"`
+		StarCount       int    `json:"star_count,omitempty"`
+		CommentCount    int    `json:"comment_count,omitempty"`
+		DateCreated     int    `json:"date_created,omitempty"`
+		Dockerfile      string `json:"dockerfile,omitempty"`
+		RepoName        string `json:"repo_name,omitempty"`
+	}
+)

--- a/dockerhub/webhook.go
+++ b/dockerhub/webhook.go
@@ -1,0 +1,8 @@
+package dockerhub
+
+type (
+	Webhook struct {
+		PushData   *PushData   `json:"push_data,omitempty"`
+		Repository *Repository `json:"repository,omitempty"`
+	}
+)


### PR DESCRIPTION
This enables auto-deployment from webhooks sent from the Docker Hub.
# Workflow
- Code is committed / pushed to repository (GitHub/Bitbucket)
- Docker Hub builds image
- Webhook is sent to Shipyard
- If build is a success, pull and restart containers for that repository
# Limitations
- Will re-deploy all containers that are using the image (ignores tags)
# Status
- Depends on citadel/citadel#68
- Testing can be done against `shipyard/shipyard:test`
