### PR TITLE
add webhook keys for deployment

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -53,6 +53,9 @@ func main() {
 		extensionsCommand,
 		addExtensionCommand,
 		removeExtensionCommand,
+		webhookKeysListCommand,
+		webhookKeyCreateCommand,
+		webhookKeyRemoveCommand,
 		infoCommand,
 		eventsCommand,
 	}

--- a/cli/webhookkeys.go
+++ b/cli/webhookkeys.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/codegangsta/cli"
+	"github.com/shipyard/shipyard/client"
+)
+
+var webhookKeysListCommand = cli.Command{
+	Name:   "webhook-keys",
+	Usage:  "list webhook keys",
+	Action: webhookKeysListAction,
+}
+
+func webhookKeysListAction(c *cli.Context) {
+	cfg, err := loadConfig()
+	if err != nil {
+		logger.Fatal(err)
+	}
+	m := client.NewManager(cfg)
+	keys, err := m.WebhookKeys()
+	if err != nil {
+		logger.Fatalf("error getting webhook keys: %s", err)
+		return
+	}
+	if len(keys) == 0 {
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
+	fmt.Fprintln(w, "Image\tKey")
+	for _, k := range keys {
+		fmt.Fprintf(w, "%s\t%s\n", k.Image, k.Key)
+	}
+	w.Flush()
+}
+
+var webhookKeyCreateCommand = cli.Command{
+	Name:   "add-webhook-key",
+	Usage:  "adds a webhook key",
+	Action: webhookKeyCreateAction,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "image, i",
+			Value: "",
+			Usage: "webhook key docker image",
+		},
+	},
+}
+
+func webhookKeyCreateAction(c *cli.Context) {
+	cfg, err := loadConfig()
+	if err != nil {
+		logger.Fatal(err)
+	}
+	m := client.NewManager(cfg)
+	key, err := m.NewWebhookKey(c.String("image"))
+	if err != nil {
+		logger.Fatalf("error generating webhook key: %s\n", err)
+	}
+	fmt.Printf("created key: %s\n", key.Key)
+}
+
+var webhookKeyRemoveCommand = cli.Command{
+	Name:        "remove-webhook-key",
+	Usage:       "removes a webhook key",
+	Description: "remove-webhook-key <key> [<key>]",
+	Action:      webhookKeyRemoveAction,
+}
+
+func webhookKeyRemoveAction(c *cli.Context) {
+	cfg, err := loadConfig()
+	if err != nil {
+		logger.Fatal(err)
+	}
+	m := client.NewManager(cfg)
+	removeKeys := c.Args()
+	for _, key := range removeKeys {
+		if err := m.RemoveWebhookKey(key); err != nil {
+			logger.Fatalf("error removing webhook key: %s", err)
+		}
+		fmt.Printf("removed %s\n", key)
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/citadel/citadel"
 	"github.com/shipyard/shipyard"
+	"github.com/shipyard/shipyard/dockerhub"
 )
 
 type (
@@ -358,6 +359,44 @@ func (m *Manager) AddExtension(ext *shipyard.Extension) error {
 
 func (m *Manager) RemoveExtension(id string) error {
 	if _, err := m.doRequest(fmt.Sprintf("/api/extensions/%s", id), "DELETE", 204, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) WebhookKeys() ([]*dockerhub.WebhookKey, error) {
+	keys := []*dockerhub.WebhookKey{}
+	resp, err := m.doRequest("/api/webhookkeys", "GET", 200, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&keys); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
+func (m *Manager) NewWebhookKey(image string) (*dockerhub.WebhookKey, error) {
+	k := &dockerhub.WebhookKey{
+		Image: image,
+	}
+	b, err := json.Marshal(k)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := m.doRequest("/api/webhookkeys", "POST", 200, b)
+	if err != nil {
+		return nil, err
+	}
+	var key *dockerhub.WebhookKey
+	if err := json.NewDecoder(resp.Body).Decode(&key); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func (m *Manager) RemoveWebhookKey(key string) error {
+	if _, err := m.doRequest(fmt.Sprintf("/api/webhookkeys/%s", key), "DELETE", 204, nil); err != nil {
 		return err
 	}
 	return nil

--- a/controller/manager/manager.go
+++ b/controller/manager/manager.go
@@ -845,8 +845,7 @@ func (m *Manager) WebhookKeys() ([]*dockerhub.WebhookKey, error) {
 }
 
 func (m *Manager) NewWebhookKey(image string) (*dockerhub.WebhookKey, error) {
-	// TODO: generate random sha
-	k := generateId()
+	k := generateId(16)
 	key := &dockerhub.WebhookKey{
 		Key:   k,
 		Image: image,

--- a/controller/manager/manager.go
+++ b/controller/manager/manager.go
@@ -13,6 +13,7 @@ import (
 	r "github.com/dancannon/gorethink"
 	"github.com/gorilla/sessions"
 	"github.com/shipyard/shipyard"
+	"github.com/shipyard/shipyard/dockerhub"
 	"github.com/sirupsen/logrus"
 )
 
@@ -23,6 +24,7 @@ const (
 	tblNameRoles       = "roles"
 	tblNameServiceKeys = "service_keys"
 	tblNameExtensions  = "extensions"
+	tblNameWebhookKeys = "webhook_keys"
 	storeKey           = "shipyard"
 )
 
@@ -33,6 +35,7 @@ var (
 	ErrServiceKeyDoesNotExist = errors.New("service key does not exist")
 	ErrInvalidAuthToken       = errors.New("invalid auth token")
 	ErrExtensionDoesNotExist  = errors.New("extension does not exist")
+	ErrWebhookKeyDoesNotExist = errors.New("webhook key does not exist")
 	logger                    = logrus.New()
 	store                     = sessions.NewCookieStore([]byte(storeKey))
 )
@@ -88,7 +91,7 @@ func (m *Manager) Store() *sessions.CookieStore {
 
 func (m *Manager) initdb() {
 	// create tables if needed
-	tables := []string{tblNameConfig, tblNameEvents, tblNameAccounts, tblNameRoles, tblNameServiceKeys, tblNameExtensions}
+	tables := []string{tblNameConfig, tblNameEvents, tblNameAccounts, tblNameRoles, tblNameServiceKeys, tblNameExtensions, tblNameWebhookKeys}
 	for _, tbl := range tables {
 		_, err := r.Table(tbl).Run(m.session)
 		if err != nil {
@@ -825,6 +828,87 @@ func (m *Manager) RedeployContainers(image string) error {
 		if err := m.SaveEvent(evt); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func (m *Manager) WebhookKeys() ([]*dockerhub.WebhookKey, error) {
+	res, err := r.Table(tblNameWebhookKeys).OrderBy(r.Asc("image")).Run(m.session)
+	if err != nil {
+		return nil, err
+	}
+	var keys []*dockerhub.WebhookKey
+	if err := res.All(&keys); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
+func (m *Manager) NewWebhookKey(image string) (*dockerhub.WebhookKey, error) {
+	// TODO: generate random sha
+	k := generateId()
+	key := &dockerhub.WebhookKey{
+		Key:   k,
+		Image: image,
+	}
+	if err := m.SaveWebhookKey(key); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func (m *Manager) WebhookKey(key string) (*dockerhub.WebhookKey, error) {
+	res, err := r.Table(tblNameWebhookKeys).Filter(map[string]string{"key": key}).Run(m.session)
+	if err != nil {
+		return nil, err
+
+	}
+	if res.IsNil() {
+		return nil, ErrWebhookKeyDoesNotExist
+	}
+	var k *dockerhub.WebhookKey
+	if err := res.One(&k); err != nil {
+		return nil, err
+	}
+	return k, nil
+}
+
+func (m *Manager) SaveWebhookKey(key *dockerhub.WebhookKey) error {
+	if _, err := r.Table(tblNameWebhookKeys).Insert(key).RunWrite(m.session); err != nil {
+		return err
+	}
+	evt := &shipyard.Event{
+		Type:    "add-webhook-key",
+		Time:    time.Now(),
+		Message: fmt.Sprintf("image=%s", key.Image),
+		Tags:    []string{"docker", "hub"},
+	}
+	if err := m.SaveEvent(evt); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) DeleteWebhookKey(id string) error {
+	key, err := m.WebhookKey(id)
+	if err != nil {
+		return err
+	}
+	res, err := r.Table(tblNameWebhookKeys).Get(key.ID).Delete().Run(m.session)
+	if err != nil {
+		return err
+	}
+	if res.IsNil() {
+		return ErrWebhookKeyDoesNotExist
+	}
+	evt := &shipyard.Event{
+		Type:    "delete-webhook-key",
+		Time:    time.Now(),
+		Message: fmt.Sprintf("image=%s key=%s", key.Image, key.Key),
+		Tags:    []string{"docker", "hub"},
+	}
+	if err := m.SaveEvent(evt); err != nil {
+		return err
 	}
 	return nil
 }

--- a/controller/manager/utils.go
+++ b/controller/manager/utils.go
@@ -42,10 +42,10 @@ func setEngineClient(docker *citadel.Engine, tlsConfig *tls.Config) error {
 	return docker.Connect(tc)
 }
 
-func generateId() string {
+func generateId(n int) string {
 	hash := sha256.New()
 	hash.Write([]byte(time.Now().String()))
 	md := hash.Sum(nil)
 	mdStr := hex.EncodeToString(md)
-	return mdStr
+	return mdStr[:n]
 }

--- a/controller/manager/utils.go
+++ b/controller/manager/utils.go
@@ -1,9 +1,12 @@
 package manager
 
 import (
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"net/url"
+	"time"
 
 	"github.com/citadel/citadel"
 )
@@ -37,4 +40,12 @@ func setEngineClient(docker *citadel.Engine, tlsConfig *tls.Config) error {
 	}
 
 	return docker.Connect(tc)
+}
+
+func generateId() string {
+	hash := sha256.New()
+	hash.Write([]byte(time.Now().String()))
+	md := hash.Sum(nil)
+	mdStr := hex.EncodeToString(md)
+	return mdStr
 }

--- a/controller/static/app/filters.js
+++ b/controller/static/app/filters.js
@@ -73,10 +73,10 @@ angular.module('shipyard.filters', [])
                     cls = "refresh blue";
                     break;
                 case 'add-engine':
-                    cls = "cloud upload green";
+                    cls = "cloud green";
                     break;
                 case 'remove-engine':
-                    cls = "remove";
+                    cls = "cloud";
                     break;
                 case 'add-service-key':
                     cls = "lock green";
@@ -95,6 +95,15 @@ angular.module('shipyard.filters', [])
                     break;
                 case 'delete-role':
                     cls = "user";
+                    break;
+                case 'add-webhook-key':
+                    cls = "exchange blue";
+                    break;
+                case 'delete-webhook-key':
+                    cls = "exchange";
+                    break;
+                case 'deploy':
+                    cls = "cloud upload green";
                     break;
                 default:
                     cls = "text file"

--- a/dockerhub/webhook.go
+++ b/dockerhub/webhook.go
@@ -5,4 +5,9 @@ type (
 		PushData   *PushData   `json:"push_data,omitempty"`
 		Repository *Repository `json:"repository,omitempty"`
 	}
+	WebhookKey struct {
+		ID    string `json:"id,omitempty" gorethink:"id,omitempty"`
+		Image string `json:"image,omitempty" gorethink:"image"`
+		Key   string `json:"key,omitempty" gorethink:"key"`
+	}
 )


### PR DESCRIPTION
This adds obfuscation and a layer of security for the Docker Hub deployment support.  In order to use the deploy functionality you first need to create a webhook key.  This is a SHA that is used as a key for the webhook URL from the Docker Hub.  This also adds the ability to specify an image with the webhook key.  If the payload from the webhook does not match the same image, it will not run.
