### PR TITLE
allow host ip in port bindings

### DIFF
--- a/cli/containers.go
+++ b/cli/containers.go
@@ -35,7 +35,7 @@ func containersAction(c *cli.Context) {
 	for _, c := range containers {
 		portDefs := []string{}
 		for _, port := range c.Ports {
-			p := fmt.Sprintf("%s/%d:%d", port.Proto, port.Port, port.ContainerPort)
+			p := fmt.Sprintf("%s/:%s:%d:%d", port.Proto, port.HostIp, port.Port, port.ContainerPort)
 			portDefs = append(portDefs, p)
 		}
 		ports := strings.Join(portDefs, ", ")

--- a/cli/run.go
+++ b/cli/run.go
@@ -73,7 +73,7 @@ var runCommand = cli.Command{
 		},
 		cli.StringSliceFlag{
 			Name:  "port",
-			Usage: "expose container ports. usage: --port <proto>/<host-port>:<container-port> i.e. --port tcp/:8080 --port tcp/80:8080",
+			Usage: "expose container ports. usage: --port <proto>/<host-ip>:<host-port>:<container-port> i.e. --port tcp/::8080 --port tcp/:80:8080, tcp/10.1.2.3:80:8080",
 			Value: &cli.StringSlice{},
 		},
 		cli.BoolFlag{

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -68,12 +68,13 @@ func parsePorts(pairs []string) []*citadel.Port {
 		portDef := parts[1]
 		// parse ports
 		portParts := strings.Split(portDef, ":")
-		if len(portParts) != 2 {
-			logger.Error("port definitions must be in <proto>/<host-port>:<container-port> pairs")
+		if len(portParts) != 3 {
+			logger.Error("port definitions must be in <proto>/<host-ip>:<host-port>:<container-port> pairs")
 			return nil
 		}
-		hostPortDef := portParts[0]
-		containerPortDef := portParts[1]
+		hostIp := portParts[0]
+		hostPortDef := portParts[1]
+		containerPortDef := portParts[2]
 		hostPort := 0
 		containerPort := 0
 		if hostPortDef != "" {
@@ -93,6 +94,7 @@ func parsePorts(pairs []string) []*citadel.Port {
 			containerPort = i
 		}
 		port := &citadel.Port{
+			HostIp:        hostIp,
 			Proto:         proto,
 			Port:          hostPort,
 			ContainerPort: containerPort,


### PR DESCRIPTION
This allows specifying the host IP in port bindings.

This depends on citadel/citadel#69
