### PR TITLE
add fig.yml file to be able to start shipyard with fig

### DIFF
--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,14 @@
+shipyard:
+    image: shipyard/shipyard
+    ports:
+        - "8080:8080"
+    links:
+        - rethinkdb:rethinkdb
+
+rethinkdb:
+    image: shipyard/rethinkdb
+    expose:
+        - "8080"
+        - "28015"
+        - "29015"
+


### PR DESCRIPTION
If you have fig installed on your computer, you doesn't need to type `docker run ...` two times, just `fig up`. It will pull the required images, link them together and start the containers.
