### PR TITLE
Fix for issue #294, Make ordering of containers in the UI consistent

### DIFF
--- a/controller/static/app/controllers.js
+++ b/controller/static/app/controllers.js
@@ -339,7 +339,7 @@ angular.module('shipyard.controllers', ['ngCookies'])
             });
         })
         .controller('EnginesController', function($scope, Engines) {
-            $scope.orderByField = 'name';
+            $scope.orderByField = 'engine.id';
             $scope.reverseSort = false;
             
             $scope.template = 'templates/engines.html';

--- a/controller/static/app/controllers.js
+++ b/controller/static/app/controllers.js
@@ -71,6 +71,9 @@ angular.module('shipyard.controllers', ['ngCookies'])
             });
         })
         .controller('ContainersController', function($scope, Containers) {
+            $scope.orderByField = 'id';
+            $scope.reverseSort = false;
+
             $scope.template = 'templates/containers.html';
             Containers.query(function(data){
                 $scope.containers = data;
@@ -336,6 +339,9 @@ angular.module('shipyard.controllers', ['ngCookies'])
             });
         })
         .controller('EnginesController', function($scope, Engines) {
+            $scope.orderByField = 'name';
+            $scope.reverseSort = false;
+            
             $scope.template = 'templates/engines.html';
             Engines.query(function(data){
                 $scope.engines = data;

--- a/controller/static/css/app.css
+++ b/controller/static/css/app.css
@@ -11,6 +11,9 @@ body {
     text-rendering: optimizeLegibility;
     min-width: 320px;
 }
+th a {
+    color: #000000;
+}
 a {
     cursor: pointer;
 }

--- a/controller/static/templates/containers.html
+++ b/controller/static/templates/containers.html
@@ -19,11 +19,11 @@
     <thead>
         <tr>
             <th><a href="" ng-click="orderByField='id'; reverseSort = !reverseSort">ID</a></th>
-            <th><a href="" ng-click="orderByField='name'; reverseSort = !reverseSort">Name</a></th>
-            <th><a href="" ng-click="orderByField='cpus'; reverseSort = !reverseSort">CPUs</a></th>
-            <th><a href="" ng-click="orderByField='memory'; reverseSort = !reverseSort">Memory</a></th>
+            <th><a href="" ng-click="orderByField='image.name'; reverseSort = !reverseSort">Name</a></th>
+            <th><a href="" ng-click="orderByField='image.cpus'; reverseSort = !reverseSort">CPUs</a></th>
+            <th><a href="" ng-click="orderByField='image.memory'; reverseSort = !reverseSort">Memory</a></th>
             <th><a href="" ng-click="orderByField='state'; reverseSort = !reverseSort">State</a></th>
-            <th><a href="" ng-click="orderByField='type'; reverseSort = !reverseSort">Type</a></th>
+            <th><a href="" ng-click="orderByField='image.type'; reverseSort = !reverseSort">Type</a></th>
         </tr>
     </thead>
     <tbody>

--- a/controller/static/templates/containers.html
+++ b/controller/static/templates/containers.html
@@ -18,16 +18,16 @@
 <table class="ui table" ng-show="containers">
     <thead>
         <tr>
-            <th>ID</th>
-            <th>Name</th>
-            <th>CPUs</th>
-            <th>Memory</th>
-            <th>State</th>
-            <th>Type</th>
+            <th><a href="" ng-click="orderByField='id'; reverseSort = !reverseSort">ID</a></th>
+            <th><a href="" ng-click="orderByField='name'; reverseSort = !reverseSort">Name</a></th>
+            <th><a href="" ng-click="orderByField='cpus'; reverseSort = !reverseSort">CPUs</a></th>
+            <th><a href="" ng-click="orderByField='memory'; reverseSort = !reverseSort">Memory</a></th>
+            <th><a href="" ng-click="orderByField='state'; reverseSort = !reverseSort">State</a></th>
+            <th><a href="" ng-click="orderByField='type'; reverseSort = !reverseSort">Type</a></th>
         </tr>
     </thead>
     <tbody>
-        <tr ng-repeat="c in containers">
+        <tr ng-repeat="c in containers | orderBy:orderByField:reverseSort">
             <td>
                 <a href="/#/containers/{{c.id}}">{{c.id|truncate}}</a>
             </td>

--- a/controller/static/templates/containers.html
+++ b/controller/static/templates/containers.html
@@ -20,6 +20,7 @@
         <tr>
             <th><a href="" ng-click="orderByField='id'; reverseSort = !reverseSort">ID</a></th>
             <th><a href="" ng-click="orderByField='image.name'; reverseSort = !reverseSort">Name</a></th>
+            <th><a href="" ng-click="orderByField='engine.id'; reverseSort = !reverseSort">Engine</a></th>
             <th><a href="" ng-click="orderByField='image.cpus'; reverseSort = !reverseSort">CPUs</a></th>
             <th><a href="" ng-click="orderByField='image.memory'; reverseSort = !reverseSort">Memory</a></th>
             <th><a href="" ng-click="orderByField='state'; reverseSort = !reverseSort">State</a></th>
@@ -32,6 +33,7 @@
                 <a href="/#/containers/{{c.id}}">{{c.id|truncate}}</a>
             </td>
             <td>{{c.image.name}}</td>
+            <td>{{c.engine.id}}</td>
             <td>{{c.image.cpus}}</td>
             <td>{{c.image.memory|formatMemory}}</td>
             <td>{{c.state}}</td>

--- a/controller/static/templates/engines.html
+++ b/controller/static/templates/engines.html
@@ -18,11 +18,11 @@
 <table class="ui table segment" ng-show="engines">
     <thead>
         <tr>
-            <th><a href="" ng-click="orderByField='name'; reverseSort = !reverseSort">Name</a></th>
-            <th><a href="" ng-click="orderByField='cpus'; reverseSort = !reverseSort">CPUs</a></th>
-            <th><a href="" ng-click="orderByField='memory'; reverseSort = !reverseSort">Memory</a></th>
-            <th><a href="" ng-click="orderByField='addr'; reverseSort = !reverseSort">Addr</a></th>
-            <th><a href="" ng-click="orderByField='labels'; reverseSort = !reverseSort">Labels</a></th>
+            <th><a href="" ng-click="orderByField='engine.id'; reverseSort = !reverseSort">Name</a></th>
+            <th><a href="" ng-click="orderByField='engine.cpus'; reverseSort = !reverseSort">CPUs</a></th>
+            <th><a href="" ng-click="orderByField='engine.memory'; reverseSort = !reverseSort">Memory</a></th>
+            <th><a href="" ng-click="orderByField='engine.addr'; reverseSort = !reverseSort">Addr</a></th>
+            <th><a href="" ng-click="orderByField='engine.labels'; reverseSort = !reverseSort">Labels</a></th>
         </tr>
     </thead>
     <tbody>

--- a/controller/static/templates/engines.html
+++ b/controller/static/templates/engines.html
@@ -18,15 +18,15 @@
 <table class="ui table segment" ng-show="engines">
     <thead>
         <tr>
-            <th>Name</th>
-            <th>CPUs</th>
-            <th>Memory</th>
-            <th>Addr</th>
-            <th>Labels</th>
+            <th><a href="" ng-click="orderByField='name'; reverseSort = !reverseSort">Name</a></th>
+            <th><a href="" ng-click="orderByField='cpus'; reverseSort = !reverseSort">CPUs</a></th>
+            <th><a href="" ng-click="orderByField='memory'; reverseSort = !reverseSort">Memory</a></th>
+            <th><a href="" ng-click="orderByField='addr'; reverseSort = !reverseSort">Addr</a></th>
+            <th><a href="" ng-click="orderByField='labels'; reverseSort = !reverseSort">Labels</a></th>
         </tr>
     </thead>
     <tbody>
-        <tr ng-repeat="e in engines">
+        <tr ng-repeat="e in engines | orderBy:orderByField:reverseSort">
             <td>
                 <a href="/#/engines/{{e.id}}">{{e.engine.id}}</a>
             </td>


### PR DESCRIPTION
Updated app/controller.js to have a default ordering of id for containers
and name for engines.  Introduced a scope variable to store whether the
sorting should be reversed.

I have then updated the engines and containers templates so that when a user
clicks on a heading, the table is sorted based upon the selected field.

When doing this, adding the <a> tag made the headings blue, so I've made a
modification to the CSS so that "th -> a" tags are black to remain consistent.
