### PR TITLE
Added engine healthcheck to API, CLI and UI

### DIFF
--- a/cli/engine.go
+++ b/cli/engine.go
@@ -35,10 +35,10 @@ func engineListAction(c *cli.Context) {
 		return
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
-	fmt.Fprintln(w, "ID\tName\tCpus\tMemory\tHost\tLabels")
+	fmt.Fprintln(w, "ID\tName\tCpus\tMemory\tHost\tLabels\tHealth")
 	for _, e := range engines {
 		labels := strings.Join(e.Engine.Labels, ",")
-		fmt.Fprintf(w, "%s\t%s\t%.2f\t%.2f\t%s\t%s\n", e.ID, e.Engine.ID, e.Engine.Cpus, e.Engine.Memory, e.Engine.Addr, labels)
+		fmt.Fprintf(w, "%s\t%s\t%.2f\t%.2f\t%s\t%s\t%s\n", e.ID, e.Engine.ID, e.Engine.Cpus, e.Engine.Memory, e.Engine.Addr, labels, e.Health.Status)
 	}
 	w.Flush()
 }

--- a/controller/static/templates/engines.html
+++ b/controller/static/templates/engines.html
@@ -23,6 +23,7 @@
             <th><a href="" ng-click="orderByField='engine.memory'; reverseSort = !reverseSort">Memory</a></th>
             <th><a href="" ng-click="orderByField='engine.addr'; reverseSort = !reverseSort">Addr</a></th>
             <th><a href="" ng-click="orderByField='engine.labels'; reverseSort = !reverseSort">Labels</a></th>
+            <th><a href="" ng-click="orderByField='health.status'; reverseSort = !reverseSort">Health</a></th>
         </tr>
     </thead>
     <tbody>
@@ -34,6 +35,7 @@
             <td>{{e.engine.memory}} MB</td>
             <td>{{e.engine.addr}}</td>
             <td>{{e.engine.labels.join(', ')}}</td>
+            <td>{{e.health.status}}</td>
         </tr>
     </tbody>
 </table>

--- a/engine.go
+++ b/engine.go
@@ -11,5 +11,10 @@ type (
 		SSLKey         string          `json:"ssl_key,omitempty" gorethink:"ssl_key,omitempty"`
 		CACertificate  string          `json:"ca_cert,omitempty" gorethink:"ca_cert,omitempty"`
 		Engine         *citadel.Engine `json:"engine,omitempty" gorethink:"engine,omitempty"`
+		Health         Health          `json:"health,omitempty" gorethink:"health,omitempty"`
+	}
+
+	Health struct {
+		Status string `json:"status,omitempty" gorethink:"status,omitempty"`
 	}
 )


### PR DESCRIPTION
A simple mechanism to check the health of engines in the Shipyard
cluster.  It functions by performing a HTTP GET against /v1.15/info on
each engine every 10 seconds.

It's pretty rudimentary at the moment.  I'll have a look at 
- seeing if the HTTP GET requests can be dispatched concurrently
- setting a default status for engines if they haven't had a health check performed
