### PR TITLE
Building model of logs from response and displaying as a table

### DIFF
--- a/controller/static/app/controllers.js
+++ b/controller/static/app/controllers.js
@@ -399,8 +399,9 @@ angular.module('shipyard.controllers', ['ngCookies'])
                     if(match == null || match.length < 4) {
                         continue;
                     }
+                    var prettyTime = match[1].replace(/(.*?)T(.*?)\..*/, "$1 $2") 
                     var log = {
-                        timestamp: match[1],
+                        timestamp: prettyTime, 
                         level: match[2],
                         msg: match[3]
                     }

--- a/controller/static/app/controllers.js
+++ b/controller/static/app/controllers.js
@@ -379,9 +379,36 @@ angular.module('shipyard.controllers', ['ngCookies'])
         .controller('ContainerLogsController', function($scope, $location, $routeParams, $http, flash, Container, ansi2html) {
             $scope.template = 'templates/container_logs.html';
 
+            $scope.highlight = function(log) {
+                if(log.level == "warn") {
+                    return "warning";
+                }
+                else if(log.level == "error") {
+                    return "error"
+                } else {
+                    return "";
+                }
+            }
+
             $http.get('/api/containers/' + $routeParams.id + "/logs").success(function(data){
-                $scope.logs = ansi2html.toHtml(data.replace(/\n/g, '<br/>'));
+                var logArray = data.split('\n');
+                var regex = /(.*?)\s(.*?):\s(.*)/;
+                var logs = [];
+                for(var i = 0; i < logArray.length; i++) {
+                    var match = regex.exec(logArray[i]);
+                    if(match == null || match.length < 4) {
+                        continue;
+                    }
+                    var log = {
+                        timestamp: match[1],
+                        level: match[2],
+                        msg: match[3]
+                    }
+                    logs.push(log);
+                }
+                $scope.logtable = logs;
             });
+
             Container.query({id: $routeParams.id}, function(data){
                 $scope.container = data;
             });

--- a/controller/static/templates/container_logs.html
+++ b/controller/static/templates/container_logs.html
@@ -9,6 +9,19 @@
     <i class="close icon"></i>
     {{flash.message}}
 </div>
-<div class="ui segment">
-    <div ng-bind-html="logs|unsafe"></div>
-</div>
+<table class="ui compact table segment" ng-show="logtable">
+    <thead>
+        <tr>
+            <th>Time</th>
+            <th>Level</th>
+            <th>Message</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr ng-class="highlight(l)" ng-repeat="l in logtable">
+            <td>{{l.timestamp}}</td>
+            <td>{{l.level}}</td>
+            <td>{{l.msg|unsafe}}</td>
+        </tr>
+    </tbody>
+</table>


### PR DESCRIPTION
![screen shot 2014-11-16 at 17 06 49](https://cloud.githubusercontent.com/assets/60068/5062295/035a2b52-6db3-11e4-8754-ca326aead296.png)

Creating a pull request to see what you think of this work so far... it's not ready to be merged yet though! 

Wondering if there might be any performance concerns with this for large logs?  I guess we might have that problem anyway?

The new version of samalba/dockerclient allows us to specify follow (this doesn't work with shipyard at the moment, I tried it) and a tail size if we want, too.
