### PR TITLE
Add better formatting of logs

### DIFF
--- a/controller/static/css/app.css
+++ b/controller/static/css/app.css
@@ -47,6 +47,12 @@ div.container {
 .checkbox {
     padding-right: 10px;
 }
+.logs {
+  font-family: Menlo, curier;
+  font-size: 12px;
+  word-break: break-word;
+  width: 100%;
+}
 .rowlink:hover {
     cursor: pointer;
     background-color: rgba(0, 0, 0, 0.04) !important;

--- a/controller/static/templates/container_logs.html
+++ b/controller/static/templates/container_logs.html
@@ -10,5 +10,5 @@
     {{flash.message}}
 </div>
 <div class="ui segment">
-    <div ng-bind-html="logs|unsafe"></div>
+  <pre class="logs"><div ng-bind-html="logs|unsafe"></div></pre>
 </div>


### PR DESCRIPTION
Add better formatting for the logs in the web interface.

Before:
![screen shot 2014-11-20 at 07 55 54](https://cloud.githubusercontent.com/assets/2408/5120903/b694c748-708a-11e4-92b0-f39f4c24a28b.png)

After:
![screen shot 2014-11-20 at 07 56 01](https://cloud.githubusercontent.com/assets/2408/5120907/bb407436-708a-11e4-8556-33a74a3194fc.png)
